### PR TITLE
Migrate to Detekt 2.0.0-alpha.2

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,5 +31,5 @@ repositories {
 dependencies {
   implementation(kotlin("gradle-plugin"))
   implementation("com.diffplug.spotless:spotless-plugin-gradle:8.4.0")
-  implementation("io.gitlab.arturbosch.detekt:io.gitlab.arturbosch.detekt.gradle.plugin:1.23.8")
+  implementation("dev.detekt:dev.detekt.gradle.plugin:2.0.0-alpha.2")
 }

--- a/buildSrc/src/main/kotlin/com/pkware/gradle/KotlinConventionsPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/pkware/gradle/KotlinConventionsPlugin.kt
@@ -2,9 +2,9 @@ package com.pkware.gradle
 
 import com.diffplug.gradle.spotless.SpotlessExtension
 import com.diffplug.gradle.spotless.SpotlessPlugin
-import io.gitlab.arturbosch.detekt.Detekt
-import io.gitlab.arturbosch.detekt.DetektPlugin
-import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import dev.detekt.gradle.Detekt
+import dev.detekt.gradle.extensions.DetektExtension
+import dev.detekt.gradle.plugin.DetektPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
@@ -45,8 +45,8 @@ class KotlinConventionsPlugin : Plugin<Project> {
 
     apply<DetektPlugin>()
     configure<DetektExtension> {
-      buildUponDefaultConfig = true
-      parallel = true
+      buildUponDefaultConfig.set(true)
+      parallel.set(true)
       config.from("$rootDir/detekt.yml")
     }
     configurations.named("detektPlugins") {
@@ -57,7 +57,7 @@ class KotlinConventionsPlugin : Plugin<Project> {
     val generatedFilesUnix = "$buildDirectory/generated"
     // configureEach for lazy configuration
     tasks.withType<Detekt>().configureEach {
-      jvmTarget = tasks.named<KotlinCompile>("compileKotlin").get().compilerOptions.jvmTarget.get().target
+      jvmTarget.set(tasks.named<KotlinCompile>("compileKotlin").get().compilerOptions.jvmTarget.get().target)
       exclude {
         // Work around https://github.com/detekt/detekt/issues/4743
         val absolutePath = it.file.absolutePath

--- a/detekt.yml
+++ b/detekt.yml
@@ -114,7 +114,7 @@ potential-bugs:
 
 style:
   active: true
-  UnnecessaryAbstractClass:
+  AbstractClassCanBeConcreteClass:
     ignoreAnnotated:
       - 'org.springframework.test.annotation.DirtiesContext'
       - 'org.junit.jupiter.api.parallel.Execution'
@@ -141,7 +141,7 @@ style:
     active: true
   ForbiddenImport:
     active: true
-    imports:
+    forbiddenImports:
       - 'org.junit.Assert'
       - 'org.junit.Test'
       - 'org.junit.Before'
@@ -149,7 +149,10 @@ style:
       - 'org.junit.After'
       - 'org.junit.AfterClass'
       - 'org.junit.jupiter.api.Assertions'
-    forbiddenPatterns: '(?:junit\.framework|org\.junit\.jupiter\.api\.Assertions)\.(?!assertThrows).+'
+      - 'junit.framework.*'
+      - 'org.junit.jupiter.api.Assertions.*'
+    allowedImports:
+      - 'org.junit.jupiter.api.Assertions.assertThrows'
   ForbiddenComment:
     comments:
       - reason: 'Forbidden FIXME todo marker in comment, please fix the problem.'
@@ -203,12 +206,12 @@ style:
     active: true
   RedundantExplicitType:
     active: true
-  RedundantVisibilityModifierRule:
+  RedundantVisibilityModifier:
     # TODO CORE-7729: Turn on
     active: false
   ReturnCount:
     active: false
-  SpacingBetweenPackageAndImports:
+  SpacingAfterPackageDeclaration:
     active: true
   UnderscoresInNumericLiterals:
     active: true
@@ -220,7 +223,7 @@ style:
     active: false
   UnnecessaryLet:
     active: true
-  UntilInsteadOfRangeTo:
+  RangeUntilInsteadOfRangeTo:
     active: true
   UnusedPrivateProperty:
     ignoreAnnotated:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ mockito = "5.23.0"
 
 [libraries]
 assertk = "com.willowtreeapps.assertk:assertk:0.28.1"
-detekt-imports = "com.pkware.detekt:import-extension:1.2.0"
+detekt-imports = "com.pkware.detekt:import-extension:2.0.0"
 grpc-api = { module = "io.grpc:grpc-api" }
 jspecify = "org.jspecify:jspecify:1.0.0"
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }


### PR DESCRIPTION
## Summary
- Migrates the entire Detekt setup from the legacy `io.gitlab.arturbosch.detekt` namespace to `dev.detekt`
- Updates the convention plugin to use Detekt 2's `Property<T>`-based API instead of direct property assignment
- Renames 5 rules/properties in `detekt.yml` to their Detekt 2 equivalents and converts `ForbiddenImport` config to the new `forbiddenImports`/`allowedImports` format
- Bumps `com.pkware.detekt:import-extension` to 2.0.0

Closes #30

## Test plan
- [x] `./gradlew build` passes (all compile, test, and detekt tasks green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)