### PR TITLE
Upgrade to Micronaut 5 (Java 25)

### DIFF
--- a/buildSrc/src/main/kotlin/com/pkware/gradle/JavaConventionsPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/pkware/gradle/JavaConventionsPlugin.kt
@@ -23,7 +23,7 @@ class JavaConventionsPlugin : Plugin<Project> {
     apply<JavaPlugin>()
     configure<JavaPluginExtension> {
       toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(25))
       }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 junit = "6.1.0"
 ktlint = "1.5.0"
 # DO NOT DELETE - Used by the Micronaut Gradle plugin.
-micronaut = "4.10.7"
+micronaut = "5.0.1"
 # Also set in settings.gradle.kts
 micronautPlugin = "5.0.1"
 mockito = "5.23.0"

--- a/hikari-health/build.gradle.kts
+++ b/hikari-health/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
   api(mn.micronaut.jdbc)
 
   implementation(mn.micronaut.jdbc.hikari)
-  implementation(mn.reactor)
+  implementation(mn.micronaut.reactor)
 
   ksp(mn.micronaut.inject.kotlin)
 

--- a/security-grpc/build.gradle.kts
+++ b/security-grpc/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   implementation(mn.micronaut.router) {
     because("GrpcMethodRouteMatch adapts ExecutableMethod as MethodBasedRouteMatch for SecuredAnnotationRule")
   }
-  implementation(mn.reactor)
+  implementation(mn.micronaut.reactor)
 
   ksp(mn.micronaut.inject.kotlin)
 


### PR DESCRIPTION
Completes the Micronaut 5 upgrade for micronaut-utils.

The branch already bumped the Micronaut Gradle plugin and the `io.micronaut.platform.catalog` plugin to 5.0.1, but the `micronaut` framework version key in the catalog was left at 4.10.7. Because the `micronaut-library` plugin reads that key to select the framework BOM, the published artifacts were still being compiled against Micronaut 4 while the tooling was 5.x. Downstream that mismatch showed up as serde/jackson bytecode incompatibilities (a `JacksonJsonMapper` `VerifyError` when consumers forced jackson-core to the 5.x line). This aligns the framework key to 5.0.1 so the artifacts are genuinely built on Micronaut 5.

Two further changes were required to build cleanly on Micronaut 5:

- Micronaut 5 requires a Java 25 runtime, so the build toolchain is raised from 21 to 25.
- Micronaut 5's version catalog renamed the reactor accessor, so `mn.reactor` becomes `mn.micronaut.reactor` in `hikari-health` and `security-grpc`.

The full build (all module tests, which start real Micronaut contexts) passes on Micronaut 5 + Java 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)