### PR TITLE
fix(build): anchor GraalVM native plugin in root classloader

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    // Anchors GraalVM native plugin in the root classloader so sibling subprojects that
+    // get it transitively via io.micronaut.library share one classloader scope instead of
+    // each getting their own — prevents GraalVMReachabilityMetadataService type mismatch.
+    id("org.graalvm.buildtools.native") version "1.1.2" apply false
+}


### PR DESCRIPTION
## Summary

- Seven subprojects apply `io.micronaut.library`, which transitively pulls in `org.graalvm.buildtools.native`
- Gradle loaded the plugin in a separate classloader scope per project, causing `GraalVMReachabilityMetadataService` to be an incompatible type across siblings — Gradle import failed with `Cannot set the value of task ':assisted-inject-test-ksp:collectReachabilityMetadata' property 'metadataService'`
- Declaring the plugin with `apply false` in the root build script forces a single shared classloader scope, as recommended in the Gradle error message