### PR TITLE
fix(deps): anchor ktlint version to Maven artifact for Renovate

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ assertk = "com.willowtreeapps.assertk:assertk:0.28.1"
 detekt-imports = "com.pkware.detekt:import-extension:2.1.0"
 grpc-api = { module = "io.grpc:grpc-api" }
 jspecify = "org.jspecify:jspecify:1.0.0"
+# Unused at runtime — exists so Renovate can track ktlint releases via Maven coordinates.
+ktlint = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint" }
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 mock-oauth2-server = "no.nav.security:mock-oauth2-server:4.0.1"
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }


### PR DESCRIPTION
## Summary

- Renovate ignores standalone `[versions]` entries with no library/plugin reference — no Maven coordinate to check for updates
- Added `ktlint` library entry pointing to `com.pinterest.ktlint:ktlint-cli` so Renovate can track releases
- Entry is unused at runtime; Spotless reads the version via `libs.findVersion("ktlint")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)