### PR TITLE
chore: publish to Maven Central via vanniktech gradle-maven-publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,28 +26,10 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0 # zizmor: ignore[cache-poisoning]
 
       - name: Publish to Maven Central
-        run: ./gradlew publish
+        run: ./gradlew publishToMavenCentral
         env:
-          ORG_GRADLE_PROJECT_NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-
-      - name: Check if release version
-        id: version-check
-        run: |
-          version=$(./gradlew properties -q | grep "^version:" | cut -d' ' -f2)
-          if [[ "$version" != *"-SNAPSHOT" ]]; then
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Notify Central Publisher Portal
-        if: steps.version-check.outputs.is_release == 'true'
-        run: |
-          token=$(echo -n "${{ secrets.NEXUS_USERNAME }}:${{ secrets.NEXUS_PASSWORD }}" | base64)
-          curl -X POST \
-            --max-time 30 \
-            --fail-with-body \
-            -H "Authorization: Bearer $token" \
-            "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.pkware.micronaut-utils?publishing_type=automatic"
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -32,4 +32,5 @@ dependencies {
   implementation(kotlin("gradle-plugin"))
   implementation("com.diffplug.spotless:spotless-plugin-gradle:8.7.0")
   implementation("dev.detekt:dev.detekt.gradle.plugin:2.0.0-alpha.5")
+  implementation("com.vanniktech:gradle-maven-publish-plugin:0.37.0")
 }

--- a/buildSrc/src/main/kotlin/com/pkware/gradle/CommonPom.kt
+++ b/buildSrc/src/main/kotlin/com/pkware/gradle/CommonPom.kt
@@ -1,0 +1,51 @@
+package com.pkware.gradle
+
+import org.gradle.api.Project
+import org.gradle.api.publish.maven.MavenPom
+
+/**
+ * Applies the POM metadata shared by every published `com.pkware.micronaut-utils` artifact.
+ *
+ * @param project the project being published; supplies `name`/`description` defaults via
+ *   the [pomName] and [pomDescription] accessors, which honor the optional `POM_NAME` and
+ *   `POM_DESCRIPTION` Gradle properties.
+ */
+internal fun MavenPom.configureCommonPom(project: Project) {
+  name.set(project.pomName)
+  description.set(project.pomDescription)
+  url.set("https://github.com/pkware/micronaut-utils")
+
+  organization {
+    name.convention("PKWARE, Inc.")
+    url.convention("https://www.pkware.com")
+  }
+
+  developers {
+    developer {
+      id.set("all")
+      name.set("PKWARE, Inc.")
+    }
+  }
+
+  scm {
+    connection.set("scm:git:git://github.com/pkware/micronaut-utils.git")
+    developerConnection.set("scm:git:ssh://github.com/pkware/micronaut-utils.git")
+    url.set("https://github.com/pkware/micronaut-utils")
+  }
+
+  licenses {
+    license {
+      name.set("MIT License")
+      distribution.set("repo")
+      url.set("https://github.com/pkware/micronaut-utils/blob/main/LICENSE")
+    }
+  }
+}
+
+/** POM artifact name; defaults to the project name, overridable via the `POM_NAME` property. */
+internal val Project.pomName: String
+  get() = properties.getOrDefault("POM_NAME", name).toString()
+
+/** POM description; defaults to [pomName], overridable via the `POM_DESCRIPTION` property. */
+internal val Project.pomDescription: String
+  get() = properties.getOrDefault("POM_DESCRIPTION", pomName).toString()

--- a/buildSrc/src/main/kotlin/com/pkware/gradle/CommonPublishing.kt
+++ b/buildSrc/src/main/kotlin/com/pkware/gradle/CommonPublishing.kt
@@ -1,0 +1,21 @@
+package com.pkware.gradle
+
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import org.gradle.api.Project
+
+/**
+ * Applies the publishing configuration shared by every published module: Maven Central coordinates,
+ * auto-released Central Portal publishing, CI-only signing, and the [common POM][configureCommonPom].
+ * The caller is responsible for selecting the platform (`configure(JavaLibrary(...))` or
+ * `configure(VersionCatalog())`) before invoking this.
+ *
+ * @param project the project being published; supplies the Maven coordinates and POM metadata.
+ */
+internal fun MavenPublishBaseExtension.configureCommonPublishing(project: Project) {
+  coordinates(project.group.toString(), project.name, project.version.toString())
+  publishToMavenCentral(automaticRelease = true)
+  if (System.getenv().containsKey("CI")) {
+    signAllPublications()
+  }
+  pom { configureCommonPom(project) }
+}

--- a/buildSrc/src/main/kotlin/com/pkware/gradle/PublishCatalogConventionPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/pkware/gradle/PublishCatalogConventionPlugin.kt
@@ -1,101 +1,24 @@
 package com.pkware.gradle
 
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.VersionCatalog
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.getByType
-import org.gradle.kotlin.dsl.register
-import org.gradle.plugins.signing.SigningExtension
-import org.gradle.plugins.signing.SigningPlugin
 
 /**
- * Plugin for publishing Gradle version catalogs.
- *
- * Adapts the standard publishing convention for version catalogs, which use the
- * `versionCatalog` component instead of the `java` component and don't require
- * Javadoc or sources jars.
+ * Configures the version-catalog module to publish to Maven Central via the vanniktech
+ * maven-publish plugin. Uses the `versionCatalog` software component (packaging `toml`) instead of
+ * the `java` component. Signing is applied only on CI.
  */
 class PublishCatalogConventionPlugin : Plugin<Project> {
   override fun apply(target: Project): Unit = target.run {
-    apply<MavenPublishPlugin>()
+    apply(plugin = "com.vanniktech.maven.publish.base")
 
-    configure<PublishingExtension> {
-      publications {
-        register<MavenPublication>("mavenCatalog") {
-          // Version catalog component is registered by the version-catalog plugin
-          val versionCatalogComponent = components.findByName("versionCatalog")
-          if (versionCatalogComponent != null) {
-            from(versionCatalogComponent)
-          }
-          pom {
-            name.set(pomName)
-            description.set(pomDescription)
-            packaging = pomPackaging
-            url.set("https://github.com/pkware/norm")
-
-            organization {
-              name.convention("PKWARE, Inc.")
-              url.convention("https://www.pkware.com")
-            }
-
-            developers {
-              developer {
-                id.set("all")
-                name.set("PKWARE, Inc.")
-              }
-            }
-
-            scm {
-              connection.set("scm:git:git://github.com/pkware/norm.git")
-              developerConnection.set("scm:git:ssh://github.com/pkware/norm.git")
-              url.set("https://github.com/pkware/norm")
-            }
-
-            licenses {
-              license {
-                name.set("MIT License")
-                distribution.set("repo")
-                url.set("https://github.com/pkware/norm/blob/main/LICENSE")
-              }
-            }
-          }
-        }
-      }
-      repositories {
-        maven {
-          name = "MavenCentral"
-          url = uri(if (version.toString().isReleaseBuild) releaseRepositoryUrl else snapshotRepositoryUrl)
-          credentials {
-            username = repositoryUsername
-            password = repositoryPassword
-          }
-        }
-      }
-    }
-
-    val isCiServer = System.getenv().containsKey("CI")
-    if (isCiServer) {
-      pluginManager.apply(SigningPlugin::class.java)
-      configure<SigningExtension> {
-        // Signing credentials are stored as secrets in GitHub.
-        // See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials for more information.
-
-        useInMemoryPgpKeys(
-          signingKeyId,
-          signingKey,
-          signingPassword,
-        )
-
-        val publishExtension = extensions.getByType<PublishingExtension>()
-        val publication = publishExtension.publications.findByName("mavenCatalog")
-        if (publication != null) {
-          sign(publication)
-        }
-      }
+    configure<MavenPublishBaseExtension> {
+      configure(VersionCatalog())
+      configureCommonPublishing(this@run)
     }
   }
 }

--- a/buildSrc/src/main/kotlin/com/pkware/gradle/PublishConventionPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/pkware/gradle/PublishConventionPlugin.kt
@@ -1,136 +1,32 @@
 package com.pkware.gradle
 
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SourcesJar
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.getByType
-import org.gradle.kotlin.dsl.register
-import org.gradle.plugins.signing.SigningExtension
-import org.gradle.plugins.signing.SigningPlugin
 
 /**
- * Plugin for projects that publish.
+ * Configures a library module to publish to Maven Central via the vanniktech maven-publish plugin.
+ *
+ * Java modules publish a real javadoc jar; Kotlin modules publish an empty one (their public API is
+ * Kotlin and the javadoc task has no public Java types to document). Signing is applied only on CI.
  */
 class PublishConventionPlugin : Plugin<Project> {
   override fun apply(target: Project): Unit = target.run {
-    apply<MavenPublishPlugin>()
+    apply(plugin = "com.vanniktech.maven.publish.base")
 
-    configure<PublishingExtension> {
-      publications {
-        register<MavenPublication>("mavenJava") {
-          from(components["java"])
-          pom {
-            name.set(pomName)
-            description.set(pomDescription)
-            packaging = pomPackaging
-            url.set("https://github.com/pkware/norm")
-
-            organization {
-              name.convention("PKWARE, Inc.")
-              url.convention("https://www.pkware.com")
-            }
-
-            developers {
-              developer {
-                id.set("all")
-                name.set("PKWARE, Inc.")
-              }
-            }
-
-            scm {
-              connection.set("scm:git:git://github.com/pkware/norm.git")
-              developerConnection.set("scm:git:ssh://github.com/pkware/norm.git")
-              url.set("https://github.com/pkware/norm")
-            }
-
-            licenses {
-              license {
-                name.set("MIT License")
-                distribution.set("repo")
-                url.set("https://github.com/pkware/norm/blob/main/LICENSE")
-              }
-            }
-          }
-        }
+    configure<MavenPublishBaseExtension> {
+      val javadocJar = if (plugins.hasPlugin("org.jetbrains.kotlin.jvm")) {
+        JavadocJar.Empty()
+      } else {
+        JavadocJar.Javadoc()
       }
-      repositories {
-        maven {
-          name = "MavenCentral"
-          url = uri(if (version.toString().isReleaseBuild) releaseRepositoryUrl else snapshotRepositoryUrl)
-          credentials {
-            username = repositoryUsername
-            password = repositoryPassword
-          }
-        }
-      }
-    }
-
-    val isCiServer = System.getenv().containsKey("CI")
-    if (isCiServer) {
-      pluginManager.apply(SigningPlugin::class.java)
-      configure<SigningExtension> {
-        // Signing credentials are stored as secrets in GitHub.
-        // See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials for more information.
-
-        useInMemoryPgpKeys(
-          signingKeyId,
-          signingKey,
-          signingPassword,
-        )
-
-        sign(extensions.getByType<PublishingExtension>().publications["mavenJava"])
-      }
-    }
-
-    extensions.configure<JavaPluginExtension> {
-      withJavadocJar()
-      withSourcesJar()
+      configure(JavaLibrary(javadocJar = javadocJar, sourcesJar = SourcesJar.Sources()))
+      configureCommonPublishing(this@run)
     }
   }
 }
-
-val String.isReleaseBuild
-  get() = !contains("SNAPSHOT")
-
-val Project.releaseRepositoryUrl: String
-  get() = properties.getOrDefault(
-    "RELEASE_REPOSITORY_URL",
-    "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2",
-  ).toString()
-
-val Project.snapshotRepositoryUrl: String
-  get() = properties.getOrDefault(
-    "SNAPSHOT_REPOSITORY_URL",
-    "https://central.sonatype.com/repository/maven-snapshots/",
-  ).toString()
-
-val Project.repositoryUsername: String
-  get() = properties.getOrDefault("NEXUS_USERNAME", "").toString()
-
-val Project.repositoryPassword: String
-  get() = properties.getOrDefault("NEXUS_PASSWORD", "").toString()
-
-val Project.signingKeyId: String
-  get() = properties.getOrDefault("SIGNING_KEY_ID", "").toString()
-
-val Project.signingKey: String
-  get() = properties.getOrDefault("SIGNING_KEY", "").toString()
-
-val Project.signingPassword: String
-  get() = properties.getOrDefault("SIGNING_PASSWORD", "").toString()
-
-val Project.pomPackaging: String
-  get() = properties.getOrDefault("POM_PACKAGING", "jar").toString()
-
-val Project.pomName: String
-  get() = properties.getOrDefault("POM_NAME", name).toString()
-
-val Project.pomDescription: String
-  get() = properties.getOrDefault("POM_DESCRIPTION", pomName).toString()
-

--- a/catalog/gradle.properties
+++ b/catalog/gradle.properties
@@ -1,3 +1,2 @@
 POM_NAME=Micronaut Utils Version Catalog
 POM_DESCRIPTION=Version catalog for Micronaut utility libraries
-POM_PACKAGING=toml

--- a/json-moshi/build.gradle.kts
+++ b/json-moshi/build.gradle.kts
@@ -41,12 +41,3 @@ micronaut {
 tasks.named<JavaCompile>("compileJava") {
   options.compilerArgs.add("-proc:none")
 }
-
-// The public API of this module is entirely Kotlin; the only Java source is package-info.java,
-// which declares no public/protected types. The Java `javadoc` task (pulled in by
-// publish-conventions via withJavadocJar()) therefore fails with "No public or protected classes
-// found to document". Exclude package-info.java so the task has no Java sources to process and is
-// skipped (NO-SOURCE), producing an empty javadoc jar consistent with a Kotlin-only public API.
-tasks.named<Javadoc>("javadoc") {
-  exclude("**/package-info.java")
-}


### PR DESCRIPTION
## Summary

Replaces the hand-rolled buildSrc Maven-publish convention plugins with the [vanniktech gradle-maven-publish plugin](https://github.com/vanniktech/gradle-maven-publish-plugin) (base plugin, 0.37.0). The custom plugins reimplemented repository-URL resolution, credential lookup, signing wiring, and POM construction — roughly 200 lines of bespoke Gradle that the vanniktech plugin provides as a maintained convention. Net change: +104 / −240.

## What changed

- **Both convention plugins are kept as thin wrappers** (`PublishConventionPlugin`, `PublishCatalogConventionPlugin`) so the `catalog` module's `this is PublishConventionPlugin` detection is unaffected. Each applies the vanniktech base plugin, selects its platform (`JavaLibrary` / `VersionCatalog`), and delegates to a single shared `configureCommonPublishing` helper — so coordinates, auto-released Central Portal publishing, CI-only signing, and POM metadata have one definition.
- **POM URLs fixed.** They were copy-pasted from the `norm` project and pointed consumers at the wrong repository; now resolve to `pkware/micronaut-utils`.
- **Javadoc handling.** Java modules publish a real javadoc jar; Kotlin modules publish an empty one (their public API is Kotlin, so the Java javadoc task has nothing to document). This removes the `json-moshi` `package-info.java` javadoc workaround that existed only to satisfy the old `withJavadocJar()`.
- **CI** publishes with `./gradlew publishToMavenCentral` + `automaticRelease`, uploading and releasing in one step — replacing `./gradlew publish` plus a manual `curl` to the OSSRH staging API. Workflow env vars are remapped to vanniktech property names; GitHub secrets are unchanged.

## Verification

Fresh `./gradlew build` + `publishToMavenLocal` succeed for all 8 library modules and the catalog. Inspected the published artifacts: a Java module (`assisted-inject`) carries real javadoc HTML, a Kotlin module (`json-moshi`) carries an empty javadoc jar, every POM points at `micronaut-utils` with zero `norm` references, and the version catalog (generated with all modules configured) still lists all 8 libraries. `./gradlew check` passes.

The first real Central Portal release can only be exercised in CI — watch the first non-SNAPSHOT publish to confirm `automaticRelease` lands the deployment rather than leaving it staged, and that the `NEXUS_*` secrets are a Central Portal token pair.

## Out of scope

While migrating, I confirmed a pre-existing bug: the published version catalog is empty/partial under config-cache + configure-on-demand because module detection depends on sibling configuration ordering. It's independent of this change (the marker class is retained, so detection behaves identically before/after). Filed as #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
